### PR TITLE
Correction of the MQTT Topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A Python script that takes a real time json stream from Enphase Envoy and publis
 #
 sensor:
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     name: "mqtt_production"
     qos: 0
     unit_of_measurement: "W"
@@ -71,7 +71,7 @@ sensor:
     device_class: power
 
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     value_template: '{{ value_json["total-consumption"]["ph-a"]["p"] }}'
     name: "mqtt_consumption"
     qos: 0
@@ -80,7 +80,7 @@ sensor:
     device_class: power
 
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     name: "mqtt_power_factor"
     qos: 0
     unit_of_measurement: "%"
@@ -89,7 +89,7 @@ sensor:
     device_class: power_factor
 
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     name: "mqtt_voltage"
     qos: 0
     unit_of_measurement: "V"
@@ -139,7 +139,7 @@ sensor:
   # These ones are for Envoy via mqtt
   #
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     name: "mqtt_production"
     qos: 0
     unit_of_measurement: "W"
@@ -148,7 +148,7 @@ sensor:
     device_class: power
 
   - platform: mqtt
-    state_topic: "/envoy/json"
+    state_topic: "envoy/json"
     value_template: '{{ value_json["total-consumption"]["ph-a"]["p"] }}'
     name: "mqtt_consumption"
     qos: 0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Python script that takes a real time json stream from Enphase Envoy and publis
 
 1) Add this Repository to your Home Assistant by clicking this button  
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/vk2him/Enphase-Envoy-mqtt-json)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/helderfmf/Enphase-Envoy-mqtt-json)
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Stream mqtt from Enphase Envoy"
 description: "Converts Envoy Json to mqtt"
-version: "1.0.6"
+version: "1.0.7"
 slug: "envoy_to_mqtt_json"
 init: false
 arch:
@@ -17,6 +17,7 @@ options:
   MQTT_PORT: 1883
   envoy_host: envoy.local
   envoy_password: secret
+  TOPIC_FREEDS: Inverter/GridWatts
 
 schema:
   MQTT_HOST: str
@@ -25,3 +26,4 @@ schema:
   MQTT_PORT: int
   envoy_host: str
   envoy_password: str  
+  TOPIC_FREEDS: str

--- a/data/options.json
+++ b/data/options.json
@@ -5,4 +5,5 @@
     "MQTT_PORT": "1883",
     "envoy_host": "envoy.local",
     "envoy_password": "envoy.password"
+    "TOPIC_FREEDS": "Inverter/GridWatts"
   }

--- a/envoy_to_mqtt_json.py
+++ b/envoy_to_mqtt_json.py
@@ -48,6 +48,7 @@ MQTT_PORT = option_dict["MQTT_PORT"]
 MQTT_TOPIC = "envoy/json"  # Note - if you change this topic, you'll need to also change the value_templates in configuration.yaml
 MQTT_USER = option_dict["MQTT_USER"]     # As described in the Documentation for the HA Mosquito broker add-on, the MQTT user/password are the user setup for mqtt
 MQTT_PASSWORD = option_dict["MQTT_PASSWORD"]    # If you use an external broker, use those details instead
+MQTT_TOPIC_FREEDS = option_dict["TOPIC_FREEDS"] 
 #
 # 
 #  
@@ -167,8 +168,9 @@ def scrape_stream():
                     data = json.loads(line.replace(marker, b''))
                     json_string = json.dumps(data)
                     #pp.pprint(json_string)
-                                    
+                    json_string_freeds = data['net-consumption']['ph-a']['p']                
                     client.publish(topic= MQTT_TOPIC , payload= json_string, qos=0 )
+                    client.publish(topic= MQTT_TOPIC_FREEDS , payload= json_string_freeds, qos=0 )
 
         except requests.exceptions.RequestException as e:
             print(dt_string, ' Exception fetching stream data: %s' % e)

--- a/envoy_to_mqtt_json.py
+++ b/envoy_to_mqtt_json.py
@@ -45,7 +45,7 @@ dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
 
 MQTT_HOST = option_dict["MQTT_HOST"]  # Note - if issues connecting, use FQDN for broker IP instead of hassio.local
 MQTT_PORT = option_dict["MQTT_PORT"]
-MQTT_TOPIC = "/envoy/json"  # Note - if you change this topic, you'll need to also change the value_templates in configuration.yaml
+MQTT_TOPIC = "envoy/json"  # Note - if you change this topic, you'll need to also change the value_templates in configuration.yaml
 MQTT_USER = option_dict["MQTT_USER"]     # As described in the Documentation for the HA Mosquito broker add-on, the MQTT user/password are the user setup for mqtt
 MQTT_PASSWORD = option_dict["MQTT_PASSWORD"]    # If you use an external broker, use those details instead
 #

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: vk2him's Enphase add-on repository
-url: 'https://github.com/vk2him/Enphase-Envoy-mqtt-json'
+name: Helder Fork of vk2him's Enphase add-on repository
+url: 'https://github.com/helderfmf/Enphase-Envoy-mqtt-json'
 maintainer: vk2him <vk2him@gmail.com>


### PR DESCRIPTION
Remove the forward slash "/" from the beginning of the mqtt topic.
[https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/](url)
`Never use a leading forward slash
A leading forward slash is permitted in MQTT. For example, /myhome/groundfloor/livingroom. However, the leading forward slash introduces an unnecessary topic level with a zero character at the front. The zero does not provide any benefit and often leads to confusion.`

Its a breaking change, but its more natural to look in the mqtt explorer:
![image](https://user-images.githubusercontent.com/5622687/208238247-07b2abdf-26e0-45a9-89a3-f2e9c82f90b7.png)
